### PR TITLE
fix: only respond to the `end` event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.1",
+    "version": "0.1.2",
     "name": "visualcaptcha",
     "description": "Node.js module for visualCaptcha. Still requires you to have the front-end companion.",
     "keywords": [

--- a/visualCaptcha.js
+++ b/visualCaptcha.js
@@ -191,19 +191,6 @@ visualCaptcha = {
                                 response.end();
                             }
                         });
-
-                        stream.on( 'close', function() {
-                            if ( ! response.headerSent ) {
-                                var finalData = Buffer.concat( responseData );
-                                response.write( finalData );
-
-                                // Add some noise randomly, so audio files can't be saved and matched easily by filesize or checksum
-                                var noiseData = crypto.randomBytes(Math.round((Math.random() * 1999)) + 501).toString('hex');
-                                response.write( noiseData );
-
-                                response.end();
-                            }
-                        });
                     } else {
                         response.status( 404 ).send( 'Not Found' );
                     }
@@ -265,19 +252,6 @@ visualCaptcha = {
                         });
 
                         stream.on( 'end', function() {
-                            if ( ! response.headerSent ) {
-                                var finalData = Buffer.concat( responseData );
-                                response.write( finalData );
-
-                                // Add some noise randomly, so images can't be saved and matched easily by filesize or checksum
-                                var noiseData = crypto.randomBytes(Math.round((Math.random() * 1999)) + 501).toString('hex');
-                                response.write( noiseData );
-
-                                response.end();
-                            }
-                        });
-
-                        stream.on( 'close', function() {
                             if ( ! response.headerSent ) {
                                 var finalData = Buffer.concat( responseData );
                                 response.write( finalData );


### PR DESCRIPTION
in node 4 and 5 both the `end` and `close` events are fired while `response.headerSent` is false. The `end` event is the definitive event when the file has been read.